### PR TITLE
Include support for Python 3.14

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: pipx install nox uv
-    - run: nox -p 3.13  # Only test on 3.13 because Windows CI is so slow.
+    - run: nox -p 3.14  # Only test on 3.14 because Windows CI is so slow.
     - uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ github.job }}-${{ strategy.job-index }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 .vscode/
 uv.lock
+.complexipy_cache/
 .coverage*
 .python-version
 .venv/

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,6 +22,9 @@ for py in FT_PYTHONS:
 
 @nox.session(python=ALL_PYTHONS)
 def tests(session: nox.Session) -> None:
+    free_threading = session.python.endswith("t")
+    if free_threading:
+        session.skip("Skipping tests on free threading Python builds.")
     coverage_file = f".coverage.{sys.platform}.{session.python}"
     pytest_env = {
         "COVERAGE_FILE": coverage_file,
@@ -32,8 +35,8 @@ def tests(session: nox.Session) -> None:
     session.run("ruff", "check")
     session.run("typos")
     session.run("mypy")
-    if session.python.endswith("t"):
-        session.log("Skipping complexipy on free threading Python")
+    if free_threading:
+        session.log("Skipping complexipy on free threading Python.")
     else:
         session.run("complexipy")
     session.run("pytest", env=pytest_env)

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,12 @@ ALL_PYTHONS = [
     if cls.startswith("Programming Language :: Python :: 3.")
 ]
 
+# Include free threading builds where available
+FT_PYTHONS = ["3.14"]
+for py in FT_PYTHONS:
+    if py in ALL_PYTHONS:
+        ALL_PYTHONS.append(f"{py}t")
+
 
 @nox.session(python=ALL_PYTHONS)
 def tests(session: nox.Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ def tests(session: nox.Session) -> None:
     session.run("ruff", "check")
     session.run("typos")
     session.run("mypy")
-    session.run("complexipy", "-d", "low", "ohmqtt", "examples", "tests")
+    session.run("complexipy")
     session.run("pytest", env=pytest_env)
 
     if sys.platform.startswith("win"):

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,10 @@ def tests(session: nox.Session) -> None:
     session.run("ruff", "check")
     session.run("typos")
     session.run("mypy")
-    session.run("complexipy")
+    if session.python.endswith("t"):
+        session.log("Skipping complexipy on free threading Python")
+    else:
+        session.run("complexipy")
     session.run("pytest", env=pytest_env)
 
     if sys.platform.startswith("win"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: Free Threading :: 2 - Beta",
+    "Programming Language :: Python :: Free Threading :: 1 - Unstable",
     "Topic :: Communications",
     "Topic :: Home Automation",
     "Topic :: Internet",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Topic :: Communications",
     "Topic :: Home Automation",
     "Topic :: Internet",
@@ -45,28 +47,28 @@ packages = [
 
 [dependency-groups]
 dev = [
-    "build>=1.2.2.post1",
-    "complexipy>=4.0.2",
-    "cryptography>=44.0.2",
-    "mypy>=1.15.0",
+    "build>=1.3.0",
+    "complexipy>=4.2.0",
+    "cryptography>=46.0.3",
+    "mypy>=1.18.2",
     "myst-parser>=4.0.1",
-    "pip-tools>=7.4.1",
-    "pytest>=8.3.5",
-    "pytest-cov>=6.0.0",
-    "pytest-mock>=3.14.0",
-    "pyyaml>=6.0.2",
-    "ruff>=0.11.2",
+    "pip-tools>=7.5.2",
+    "pytest>=9.0.1",
+    "pytest-cov>=7.0.0",
+    "pytest-mock>=3.15.1",
+    "pyyaml>=6.0.3",
+    "ruff>=0.14.6",
     "sphinx>=8.1.3",
     "sphinx-rtd-theme>=3.0.2",
-    "types-pyyaml>=6.0.12.20250402",
-    "typos>=1.31.1",
+    "types-pyyaml>=6.0.12.20250915",
+    "typos>=1.39.2",
 ]
 profile = [
-    "austin-dist>=3.7.0",
-    "austin-tui>=1.3.0",
-    "memray>=1.17.2; platform_system != 'Windows'",
+    "austin-dist>=4.0.0",
+    "austin-tui>=1.4.1",
+    "memray>=1.19.1; platform_system != 'Windows'",
     "pympler>=1.1",
-    "yappi>=1.6.10",
+    "yappi>=1.7.3",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,10 @@ ignore = ["PLC0414", "PT011"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["E731", "PERF", "PL"]
 
+[tool.complexipy]
+paths = ["ohmqtt", "examples", "tests"]
+failed = true
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ packages = [
 [dependency-groups]
 dev = [
     "build>=1.3.0",
-    "complexipy>=4.2.0",
+    "complexipy>=5.0.0",
     "cryptography>=46.0.3",
     "mypy>=1.18.2",
     "myst-parser>=4.0.1",


### PR DESCRIPTION
* Update minimum dependency versions to guarantee compatibility.
* Special handling of free-threading tag for 3.14.
* Skip testing of free-threading 3.14, because it is unstable.